### PR TITLE
Add ryl-markdown hook to lint YAML embedded in Markdown

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,10 @@
   language: python
   types: [yaml]
   minimum_pre_commit_version: "2.9.2"
+- id: ryl-markdown
+  name: ryl (markdown)
+  description: "Lint YAML embedded in Markdown (front matter + fenced yaml blocks)"
+  entry: ryl --markdown
+  language: python
+  files: \.(md|markdown|mdx|qmd|Rmd)$
+  minimum_pre_commit_version: "2.9.2"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ custom configuration file:
         args: [--config-file, configs/yl.yml]
 ```
 
+## Linting YAML embedded in Markdown
+
+The `ryl` hook above only sees YAML files. To also lint YAML embedded in
+Markdown — front matter and fenced `yaml`/`yml` blocks — add the `ryl-markdown`
+hook, which runs `ryl --markdown` and so needs no extra `[files]` config:
+
+```yaml
+  - repo: https://github.com/owenlamont/ryl-pre-commit
+    rev: v0.11.0
+    hooks:
+      - id: ryl
+      - id: ryl-markdown
+```
+
+It targets `.md`, `.markdown`, `.mdx`, `.qmd`, and `.Rmd` files. To autofix the
+embedded YAML in place, add `args: [--fix]`:
+
+```yaml
+      - id: ryl-markdown
+        args: [--fix]
+```
+
+Requires `ryl >= 0.11.0`.
+
 ## License
 
 MIT (see [LICENSE](LICENSE))


### PR DESCRIPTION
## Summary

Adds a second, opt-in pre-commit hook `ryl-markdown` that runs `ryl --markdown`, linting YAML **embedded in Markdown** — front matter and fenced `yaml`/`yml` blocks — with diagnostics mapped back to the host file. The `--markdown` flag injects the default markdown globs (`*.md`, `*.markdown`, `*.mdx`, `*.qmd`, `*.Rmd`), so it's turnkey: no `[files]` config needed and the "no source kind matches" error can't fire.

```yaml
- id: ryl-markdown
  name: ryl (markdown)
  description: "Lint YAML embedded in Markdown (front matter + fenced yaml blocks)"
  entry: ryl --markdown
  language: python
  files: \.(md|markdown|mdx|qmd|Rmd)$
  minimum_pre_commit_version: "2.9.2"
```

Notes:
- Uses a `files:` regex rather than `types: [markdown]` because pre-commit's `identify` only tags `.md`/`.markdown` as `markdown`; `.qmd`/`.Rmd`/`.mdx` need the regex.
- The existing `ryl` hook stays `types: [yaml]` — markdown linting is strictly opt-in, so current users are unaffected.
- Requires `ryl >= 0.11.0` (already the pinned version via the lockstep release workflow).
- Users wanting autofix can add `args: [--fix]`; `--fix` write-back for embedded YAML is supported in 0.11.0.

README gains a "Linting YAML embedded in Markdown" section documenting the hook, targeted extensions, and the `--fix` variant.

## Testing

Upgraded the local `ryl` to 0.11.0 and tested end-to-end with `prek try-repo`, which installs `ryl==0.11.0` in an isolated env like a real consumer:

- ✅ Flags broken YAML in both front matter and fenced `yaml` blocks, line numbers mapped to the host file
- ✅ Clean Markdown passes
- ✅ Extension routing works for `.qmd`, `.Rmd`, `.mdx` (not just `.md`)
- ✅ `--fix` rewrites the embedded block in place (`[a,b,c]` → `[a, b, c]`) and exits 0
- ✅ Original `ryl` hook still lints `.yaml` and skips Markdown
- ✅ `prek run --all-files` passes on the repo

Closes #15