### PR TITLE
Harden mirror push (concurrency + atomic) and drop stale ruff per-file-ignore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,10 @@ on:
   repository_dispatch:
     types: [pypi_release]
 
+concurrency:
+  group: mirror
+  cancel-in-progress: false
+
 permissions: {}
 
 jobs:
@@ -58,7 +62,7 @@ jobs:
             exit 0
           fi
 
-          git push origin HEAD:refs/heads/main --tags
+          git push --atomic origin HEAD:refs/heads/main --tags
 
       - name: Reconcile releases from tags
         env:

--- a/ruff.toml
+++ b/ruff.toml
@@ -61,7 +61,6 @@ preview = true
 
 [lint.per-file-ignores]
 "tests/**" = ["D102", "D103", "S101"]
-"tests/uv_secure/package_info/test_dependency_file_parser.py" = ["E501"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]


### PR DESCRIPTION
## What

Two small hardening/cleanup changes to the mirror workflow and lint config:

1. **Serialize mirror runs + atomic push.** Add a `concurrency: { group: mirror, cancel-in-progress: false }` group and push `main` + tags with `git push --atomic`.

   Why: `mirror.py` creates the `vX.Y.Z` tag right after committing, but the push step later runs `git rebase origin/main`. Git does not move tags during a rebase, so if `origin/main` advanced mid-run, `HEAD` would be rewritten while the tag still pointed at the pre-rebase commit — the pushed tag/release could end up off `main`'s history, or a non-atomic push could land the tag while the `main` update is rejected. Only this workflow pushes to `main`, so the concurrency group (no overlapping runs) makes the rebase a no-op, and `--atomic` makes `main`+tags all-or-nothing. Very low-probability in practice, but free to close off.

2. **Drop a dead per-file-ignore.** `ruff.toml` ignored `E501` for `tests/uv_secure/package_info/test_dependency_file_parser.py`, a path that does not exist in this repo (copy-paste leftover).

## Notes

The same hardening is applied to the new sibling `lychee-pre-commit` repo, so the two mirrors stay in parity.
