### PR TITLE
Switch hook entry to `ryl check` (#20)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,14 +1,14 @@
 - id: ryl
   name: ryl
   description: "Lint YAML files with the ryl CLI"
-  entry: ryl
+  entry: ryl check
   language: python
   types: [yaml]
   minimum_pre_commit_version: "2.9.2"
 - id: ryl-markdown
   name: ryl (markdown)
   description: "Lint YAML embedded in Markdown (front matter + fenced yaml blocks)"
-  entry: ryl --markdown
+  entry: ryl check --markdown
   language: python
   files: \.(md|markdown|mdx|qmd|Rmd)$
   minimum_pre_commit_version: "2.9.2"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ custom configuration file:
 
 The `ryl` hook above only sees YAML files. To also lint YAML embedded in
 Markdown — front matter and fenced `yaml`/`yml` blocks — add the `ryl-markdown`
-hook, which runs `ryl --markdown` and so needs no extra `[files]` config:
+hook, which runs `ryl check --markdown` and so needs no extra `[files]` config:
 
 ```yaml
   - repo: https://github.com/owenlamont/ryl-pre-commit


### PR DESCRIPTION
Closes #20.

## What

Switch the hook `entry` to the explicit `ryl check` lint subcommand, now that
the pin in `pyproject.toml` is `ryl==0.21.0` — the first ryl release containing
`ryl check` (owenlamont/ryl#369), the first slice of ryl's lint/format split
(owenlamont/ryl#238).

`.pre-commit-hooks.yaml`:

- `ryl` hook:          `entry: ryl`            → `entry: ryl check`
- `ryl-markdown` hook: `entry: ryl --markdown` → `entry: ryl check --markdown`

Hook **ids stay `ryl` / `ryl-markdown`**, so users' `.pre-commit-config.yaml`
needs no change — only the internal invocation moves to the supported form.
The README line describing the markdown hook now says it runs
`ryl check --markdown`; the `- id: ryl` usage examples are unchanged.

## Why it's zero-breakage

This repo is a version mirror: each tag pins the matching `ryl==X.Y.Z`, and
pre-commit reads `.pre-commit-hooks.yaml` at the user's pinned `rev`, so the
`entry` and the ryl version always move together. Old revs keep `entry: ryl`
with their old ryl; new revs get `entry: ryl check` with a ryl that supports it.
`ryl check` is additive and behaves identically to bare `ryl <paths>`, so no
user is ever left invoking a command their pinned ryl lacks.

## Verification

With ryl 0.21.0:

- `ryl check --help` lists the lint flags (`--config-file`, `--fix`,
  `--markdown`, `--diff`, …); its summary is "Lint YAML inputs (the explicit
  form of bare `ryl <paths>`)".
- `ryl check <file>` and `ryl check --markdown <file>` produce identical output
  to the bare forms (clean → pass, dirty → same findings).
- Ran both hooks end-to-end through `pre-commit try-repo` against this branch
  (installs the pinned ryl 0.21.0 and runs the new entries):
  - `ryl`: clean YAML → Passed, dirty YAML → Failed with the expected finding.
  - `ryl-markdown`: clean Markdown → Passed, Markdown with embedded
    trailing-spaces → Failed with the expected findings.

## Release note for the maintainer

`v0.21.0` is already tagged at the `Mirror: 0.21.0` commit, so this flip is not
retroactively in `v0.21.0`. Per the automated mirror process (tags are only cut
on a new ryl version bump, after rebasing onto `main`), once this merges the
flip rides the next mirror tag, whose pin is ≥ 0.21.0 — so the gating from #20
("land in or after the first release whose pin includes `ryl check`") still
holds. No manual tag is needed; leaving the tag/publish to the existing
automation. `uv.lock` is intentionally untouched — the mirror process only
rewrites `pyproject.toml` and `README.md`, and the lockfile has never tracked
the pin.

## Out of scope

Deferred to when ryl ships `ryl format` (owenlamont/ryl#238): a `ryl-format`
hook or a canonical `ryl-check` id alongside the back-compat `ryl` id.
